### PR TITLE
fix(notifications.js): fix notifications removal with splice index

### DIFF
--- a/src/notifications.js
+++ b/src/notifications.js
@@ -18,6 +18,9 @@ export const methods = {
     }, timeout || 3000) // default time 3s
   },
   removeNotification(id) {
-    state.notifications.splice(state.notifications.findIndex(n => n.id === id), 1)
+    const found = state.notifications.findIndex((n) => n.id === id);
+    if (found >= 0) {
+      state.notifications.splice(found, 1);
+    }
   }
 };


### PR DESCRIPTION
This PR addresses a bug that delete the wrong notification from screen when you have the possibility to show multiple notifications on screen.

To reproduce:

1 - Create a custom template for group of notifications
2 - Have a way to fire multiple notifications, put a time of 5+ seconds to see more clearly
3 - Fire one of them, wait 2 seconds and dismiss it by yourself
4 - Fire another notification

You'll see that disappears before the time ends, because the splice finds the only notification left on the array and removes it